### PR TITLE
Potential fix for code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/src/api-updater.ts
+++ b/src/api-updater.ts
@@ -268,8 +268,7 @@ export class EvatrApiUpdater {
 
       // Replace the STATUS_MESSAGES object
       const statusMessagesStr = JSON.stringify(statusMessagesObj, null, 2)
-        .replace(/"/g, "'")
-        .replace(/'/g, "'");
+        .replace(/"/g, "'");
 
       const newConstantsContent = constantsContent.replace(
         /export const STATUS_MESSAGES: Record<string, ApiStatusMessage> = \{[\s\S]*?\};/,


### PR DESCRIPTION
Potential fix for [https://github.com/rechtlogisch/evatr-js/security/code-scanning/1](https://github.com/rechtlogisch/evatr-js/security/code-scanning/1)

To fix the problem, we should remove the redundant `.replace(/'/g, "'")` operation on line 272, as it does nothing. If the intention was to escape single quotes, the replacement string should be `"\\'"`. However, in the context of converting double quotes to single quotes in a JSON string, escaping single quotes is not necessary unless the string will be embedded in a context where single quotes need to be escaped (e.g., inside a single-quoted string in TypeScript/JavaScript). If escaping is needed, replace with `"\\'"`; otherwise, simply remove the line. Since there is no evidence that escaping is required, the best fix is to remove the unnecessary replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
